### PR TITLE
 fixed "Open in Browser" can't open exported ipynb in remote kernel 

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,11 +82,11 @@
           "default": null,
           "description": "remote kernel token"
         },
-				"VSNotebooks.remoteKernelHomeDir": {
-					"type": "string",
-					"default": null,
-					"description": "remote kernel home dir"
-				}
+	"VSNotebooks.remoteKernelHomeDir": {
+		"type": "string",
+		"default": null,
+		"description": "remote kernel home dir"
+	}
       }
     },
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -81,7 +81,12 @@
           "type": "string",
           "default": null,
           "description": "remote kernel token"
-        }
+        },
+				"VSNotebooks.remoteKernelHomeDir": {
+					"type": "string",
+					"default": null,
+					"description": "remote kernel home dir"
+				}
       }
     },
     "keybindings": [

--- a/src-backend/interpreter.ts
+++ b/src-backend/interpreter.ts
@@ -100,8 +100,23 @@ export class Interpreter {
         let uri;
         let baseUrl = this.serverSettings.baseUrl;
         let token = this.serverSettings.token;
+        
+        let fullPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+        let homeDir = vscode.workspace.getConfiguration('VSNotebooks').get('remoteKernelHomeDir');
+        let filepath;
+        
+        let start = fullPath.indexOf(homeDir);
+        let end = start + homeDir.length;
+        
         if (filename) {
-            uri = vscode.Uri.parse(baseUrl + 'notebooks/' + filename + '?token=' + token);
+            if(start != -1) {
+                let relativePath = fullPath.substring(end);
+                filepath = relativePath + '/' + filename;
+            }
+            else {
+                filepath = fullPath + '/' + filename;
+            }
+            uri = vscode.Uri.parse(baseUrl + 'notebooks/' + filepath + '?token=' + token);
         } else {
             uri = vscode.Uri.parse(baseUrl + '?token=' + token);
         }


### PR DESCRIPTION
If you have remote kernel running on your local, you'll find that you cannot open exported ipynb in your browser. This is because there are no file path information passed into openNotebookInBrowser(). This fixed it.